### PR TITLE
use findLast instead of find

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -75,7 +75,7 @@ export async function POST(req: Request): Promise<NextResponse> {
   }
 
   const data = await req.json();
-  const question = data.find(
+  const question = data.findLast(
     (msg: RequestBody) => msg.role === "user"
   )?.content;
 


### PR DESCRIPTION
- Using `find` to get the user's message returned the first result instead of the most recently entered question.
- `findLast` solves this by returning the last message entered